### PR TITLE
[Documentation] README:  Activate Badges and Fix Two Obvious Bugs

### DIFF
--- a/tabelle/src/main.rs
+++ b/tabelle/src/main.rs
@@ -9,12 +9,14 @@
 //!
 //! ## Summary
 //!
+//! [![][license]][repository]
+//!
 //! A simple `.csv` and `.xlsx` viewer for your terminal.
 //!
 //! ## Running & Commandline Args
 //!
 //! You can open a file by typing `tabelle file.csv` or just start a new one by
-//! running `tabelle`
+//! running `tabelle`.
 //!
 //! ## Features
 //!
@@ -29,7 +31,7 @@
 //! You need cargo installed to install this, then just execute this command:
 //!
 //! ```bash
-//! cargo install --git https://github.com/wert007/commit-analyzer
+//! cargo install --git https://github.com/wert007/tabelle
 //! ```
 //!
 //! ## Contributions


### PR DESCRIPTION
This PR fixes the following documentation bugs:

- the license badge was configured but not activated
- a description in the README missed a trailing full stop
- the download instruction was taken from another project but not adjusted

The commit description uses the CHANGELOG artifact format Aeruginous v1.1.0+ supports; Aeruginous can create you a CHANGELOG from your commit messages.  Shall I configure this for your project?

This is a very interesting project in the spirit of early Excel versions.  I hope there will be a release to crates.io in the future.