### PR TITLE
Fix csv parser bug with explicit empty cells

### DIFF
--- a/tabelle/src/dialog.rs
+++ b/tabelle/src/dialog.rs
@@ -1,4 +1,7 @@
-use std::{fmt::{Debug, Display}, io::stdout};
+use std::{
+    fmt::{Debug, Display},
+    io::stdout,
+};
 
 use crossterm::{
     cursor::{MoveDown, MoveTo, MoveToColumn},


### PR DESCRIPTION
If you had a csv file with multiple separators next to each other, without any other text, the parser failed. This is fixed and a simple test was added for this.