### PR TITLE
[Bugfix] Future `quick-xml` v0.22.0 Rejection

### DIFF
--- a/tabelle-core/Cargo.toml
+++ b/tabelle-core/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 pyo3 = "0.16.5"
 serde = { version = "1.0.143", features = ["derive"] }
-umya-spreadsheet = "0.8.0"
+umya-spreadsheet = "0.9.2"
 unicode-width = "0.1.9"

--- a/tabelle-core/src/lib.rs
+++ b/tabelle-core/src/lib.rs
@@ -101,12 +101,12 @@ impl Spreadsheet {
                     .map(|c| (*c.get_width()) as usize)
                     .unwrap_or(10);
                 let unit = worksheet
-                    .get_style_by_column_and_row(&col, &row)
+                    .get_style((&col, &row))
                     .get_numbering_format()
                     .as_ref()
                     .and_then(|n| UnitKind::try_from(n).ok())
                     .unwrap_or_default();
-                let content = if let Some(cell) = worksheet.get_cell_by_column_and_row(&col, &row) {
+                let content = if let Some(cell) = worksheet.get_cell((&col, &row)) {
                     if cell.is_formula() || cell.get_value().starts_with('=') {
                         needs_evaluation = true;
                     }
@@ -311,10 +311,10 @@ impl Spreadsheet {
                 .set_width(self.column_width(column) as f64);
             for row in 0..self.rows() {
                 worksheet
-                    .get_cell_by_column_and_row_mut(&(column as u32 + 1), &(row as u32 + 1))
+                    .get_cell_mut((&(column as u32 + 1), &(row as u32 + 1)))
                     .set_value(self.cell_at((column, row)).content.serialize_display());
                 worksheet
-                    .get_style_by_column_and_row_mut(&(column as u32 + 1), &(row as u32 + 1))
+                    .get_style_mut((&(column as u32 + 1), &(row as u32 + 1)))
                     .set_numbering_format(self.cell_at((column, row)).unit.into());
             }
         }


### PR DESCRIPTION
When compiling the project with Rust v1.70.0, I received the compiler warning that the indirect dependency `quick-xml` v0.22.0 (introduced by `umya-spreadsheet` v0.8.0) would be rejected in future Rust versions.  To fix this issue, I updated `umya-spreadsheet` to the latest available version (v0.9.2) which actually fixed the problem.

In addition to a newer version of `quick-xml`, the latest `umya-spreadsheet` version also introduces more comfortable methods with shorter names due to which some of the old ones became marked as deprecated.  So, I also switched to the new methods.

Since these changes are two different fixes, I left them as different commits.