### PR TITLE
Create ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.3
+        with:
+          persist-credentials: false
+
+      - uses: devops-actions/actionlint@v0.1.1
+
+  bors:
+    name: bors
+    needs:
+      - actionlint
+      - cargo
+    runs-on: ubuntu-latest
+    steps:
+      - run: bash -c 'exit 0'
+
+  cargo:
+    name: cargo
+    runs-on: ubuntu-latest
+    steps:
+      - run: rustup update
+
+      - uses: actions/checkout@v3.5.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - if: matrix.subcommand == 'nextest r'
+        uses: taiki-e/install-action@v2.11.0
+        with:
+          tool: nextest
+
+      - run: cargo ${{ matrix.subcommand }}
+    strategy:
+      matrix:
+        subcommand:
+          - b
+          - c
+          - clippy
+          - d
+          - fmt --check
+          - nextest r
+          - t


### PR DESCRIPTION
Fixes #14.

This is an exact copy of the current CI setup I use for Aeruginous except for the CFF linting step as we do not have any CFF here, yet.  The job `bors` is the top level CI job you can make the branch protection rules for `main` wait for before allowing for merging any incoming PR.  The name is an artifact of the former Bors configuration Aeruginous has made use of.

Bors is a merging bot for PRs with almost similar capabilities as GitHub's branch protection rules.  The sole feature which cannot be modeled with branch protection rules is the silent merging, i.e., you prevent a PR from being harvested for automatic release notes -- very useful for excluding Dependabot PRs!  When the branch protection rules were made available for all public repositories, the maintainer(s) of Bors have announced that the public instance would disappear, soon.  The main idea of Bors was to prevent changes which do not work from being introduced to the main branch; however, you can also make Bors wait for the CI to succeed instead of you such that you can continue with other changes to the project in the meantime.  If you want, you can still configure you a private instance of Bors for which you need a server it can run on.  That is why I did not change the name here, yet.